### PR TITLE
[1.7.10] Fix Cannon drop & render

### DIFF
--- a/src/main/java/ckathode/weaponmod/entity/EntityCannon.java
+++ b/src/main/java/ckathode/weaponmod/entity/EntityCannon.java
@@ -173,6 +173,7 @@ public class EntityCannon extends EntityBoat {
         }
         setRotation(rotationYaw, rotationPitch);
         moveEntity(motionX, motionY, motionZ);
+        @SuppressWarnings("unchecked")
         List<Entity> list = worldObj.getEntitiesWithinAABBExcludingEntity(this,
                 EntityProjectile.getBoundingBox(this).expand(0.2, 0.0, 0.2));
         if (list != null) {

--- a/src/main/java/ckathode/weaponmod/entity/EntityCannon.java
+++ b/src/main/java/ckathode/weaponmod/entity/EntityCannon.java
@@ -21,6 +21,7 @@ import net.minecraft.util.EntityDamageSource;
 import net.minecraft.util.EntityDamageSourceIndirect;
 import net.minecraft.util.MathHelper;
 import net.minecraft.util.Vec3;
+import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.world.World;
 import org.jetbrains.annotations.Nullable;
 
@@ -347,6 +348,11 @@ public class EntityCannon extends EntityBoat {
     public void onStruckByLightning(@Nonnull EntityLightningBolt entitylightningbolt) {
         dealFireDamage(100);
         setSuperPowered(true);
+    }
+
+    @Override
+    public ItemStack getPickedResult(MovingObjectPosition target) {
+        return new ItemStack(BalkonsWeaponMod.cannon);
     }
 
     public void setLoaded(boolean flag) {

--- a/src/main/java/ckathode/weaponmod/entity/EntityCannon.java
+++ b/src/main/java/ckathode/weaponmod/entity/EntityCannon.java
@@ -6,6 +6,7 @@ import ckathode.weaponmod.entity.projectile.EntityProjectile;
 import ckathode.weaponmod.item.WMItem;
 import java.util.List;
 import javax.annotation.Nonnull;
+import net.minecraft.block.material.Material;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.effect.EntityLightningBolt;
 import net.minecraft.entity.item.EntityBoat;
@@ -201,6 +202,32 @@ public class EntityCannon extends EntityBoat {
         int i = MathHelper.floor_float(f);
         i *= 2;
         attackEntityFrom(DamageSource.fall, (float) i);
+    }
+
+    @Override
+    protected void updateFallState(double tickFallDist, boolean isOnGround) {
+        int x = MathHelper.floor_double(posX);
+        int y = MathHelper.floor_double(posY);
+        int z = MathHelper.floor_double(posZ);
+        if(!isOnGround) {
+            if(worldObj.getBlock(x, y - 1, z).getMaterial() != Material.water && tickFallDist < 0.0) {
+                fallDistance = (float)((double)fallDistance - tickFallDist);
+            }
+            return;
+        }
+        if(!(fallDistance > 3.0F)) {
+            return;
+        }
+        fall(fallDistance);
+        if(!worldObj.isRemote && !isDead) {
+            dropItem(BalkonsWeaponMod.cannon, 1);
+            if (isLoaded() || isLoading()) {
+                dropItem(BalkonsWeaponMod.cannonBall, 1);
+                dropItem(Items.gunpowder, 1);
+            }
+            setDead();
+        }
+        fallDistance = 0.0F;
     }
 
     public void handleReloadTime() {

--- a/src/main/java/ckathode/weaponmod/render/RenderCannon.java
+++ b/src/main/java/ckathode/weaponmod/render/RenderCannon.java
@@ -19,18 +19,18 @@ public class RenderCannon extends Render {
     }
 
     @Override
-    public void doRender(Entity entity, double d, double d1, double d2, float f, float f1) {
-        renderCannon((EntityCannon) entity, d, d1, d2, f, f1);
+    public void doRender(Entity entity, double x, double y, double z, float yaw, float partialTicks) {
+        renderCannon((EntityCannon) entity, x, y, z, yaw, partialTicks);
     }
 
-    public void renderCannon(EntityCannon entitycannon, double d, double d1, double d2, float f, float f1) {
+    public void renderCannon(EntityCannon entitycannon, double x, double y, double z, float yaw, float partialTicks) {
         GL11.glPushMatrix();
-        float rot = entitycannon.prevRotationPitch + (entitycannon.rotationPitch - entitycannon.prevRotationPitch) * f1;
+        float rot = entitycannon.prevRotationPitch + (entitycannon.rotationPitch - entitycannon.prevRotationPitch) * partialTicks;
         rot = Math.min(rot, 20.0f);
-        GL11.glTranslated(d, d1 + 2.1, d2);
-        GL11.glRotatef(180.0f - f, 0.0f, 1.0f, 0.0f);
-        float f2 = entitycannon.getTimeSinceHit() - f1;
-        float f3 = entitycannon.getCurrentDamage() - f1;
+        GL11.glTranslated(x, y + 2.1, z);
+        GL11.glRotatef(180.0f - yaw, 0.0f, 1.0f, 0.0f);
+        float f2 = entitycannon.getTimeSinceHit() - partialTicks;
+        float f3 = entitycannon.getCurrentDamage() - partialTicks;
         if (f3 < 0.0f) {
             f3 = 0.0f;
         }
@@ -42,20 +42,20 @@ public class RenderCannon extends Render {
         GL11.glScalef(-1.6f, -1.6f, 1.6f);
         if (entitycannon.isSuperPowered() && entitycannon.ticksExisted % 5 < 2) {
             float f4 = 1.5f;
-            GL11.glColor3f(entitycannon.getBrightness(f1) * f4, entitycannon.getBrightness(f1) * f4,
-                    entitycannon.getBrightness(f1) * f4);
+            GL11.glColor3f(entitycannon.getBrightness(partialTicks) * f4, entitycannon.getBrightness(partialTicks) * f4,
+                    entitycannon.getBrightness(partialTicks) * f4);
         }
         GL11.glPushMatrix();
         GL11.glTranslatef(0.0f, 1.0f, 0.0f);
         GL11.glRotatef(rot, 1.0f, 0.0f, 0.0f);
         GL11.glTranslatef(0.0f, -1.0f, 0.0f);
-        modelBarrel.render(entitycannon, f1, 0.0f, -0.1f, 0.0f, 0.0f, 0.0625f);
+        modelBarrel.render(entitycannon, partialTicks, 0.0f, -0.1f, 0.0f, 0.0f, 0.0625f);
         GL11.glPopMatrix();
-        float yaw = -(float) Math.toRadians(f);
-        modelStandard.base1.rotateAngleY = yaw;
-        modelStandard.base2.rotateAngleY = yaw;
-        modelStandard.baseStand.rotateAngleY = yaw;
-        modelStandard.render(entitycannon, f1, 0.0f, -0.1f, 0.0f, 0.0f, 0.0625f);
+        float yawRadians = -(float) Math.toRadians(yaw);
+        modelStandard.base1.rotateAngleY = yawRadians;
+        modelStandard.base2.rotateAngleY = yawRadians;
+        modelStandard.baseStand.rotateAngleY = yawRadians;
+        modelStandard.render(entitycannon, partialTicks, 0.0f, -0.1f, 0.0f, 0.0f, 0.0625f);
         GL11.glPopMatrix();
     }
 

--- a/src/main/java/ckathode/weaponmod/render/RenderCannon.java
+++ b/src/main/java/ckathode/weaponmod/render/RenderCannon.java
@@ -27,6 +27,7 @@ public class RenderCannon extends Render {
         GL11.glPushMatrix();
         float rot = entitycannon.prevRotationPitch + (entitycannon.rotationPitch - entitycannon.prevRotationPitch) * partialTicks;
         rot = Math.min(rot, 20.0f);
+        yaw = interpolateRotation(entitycannon.prevRotationYaw, entitycannon.rotationYaw, partialTicks);
         GL11.glTranslated(x, y + 2.1, z);
         GL11.glRotatef(180.0f - yaw, 0.0f, 1.0f, 0.0f);
         float f2 = entitycannon.getTimeSinceHit() - partialTicks;
@@ -57,6 +58,10 @@ public class RenderCannon extends Render {
         modelStandard.baseStand.rotateAngleY = yawRadians;
         modelStandard.render(entitycannon, partialTicks, 0.0f, -0.1f, 0.0f, 0.0f, 0.0625f);
         GL11.glPopMatrix();
+    }
+
+    private float interpolateRotation(float from, float to, float by) {
+        return (from + MathHelper.wrapAngleTo180_float(to - from) * by) % 360.0f;
     }
 
     @Override


### PR DESCRIPTION
Whether in the original mod or legacy version, there are the same errors with the Cannon:
* When interacting with the middle mouse button in a creative it gives out a Boat;
* When falling from a height of 2 blocks, planks and sticks fall out, as if from a Boat;
* When the player crosses the 180.0 boundary of **rotationYaw** value, a rendering bug occurs due to poor interpolation. This one is not related to a Boat;

Fortunately, fixing this is easy; **However, I didn't build the project to test.**

BTW, *nice boat*.