### PR TITLE
Add item tags and enchantment tag

### DIFF
--- a/common/src/main/resources/data/minecraft/tags/item/enchantable/durability.json
+++ b/common/src/main/resources/data/minecraft/tags/item/enchantable/durability.json
@@ -1,0 +1,21 @@
+{
+  "values": [
+    "#weaponmod:battleaxe",
+    "#weaponmod:flail",
+    "#weaponmod:halberd",
+    "#weaponmod:katana",
+    "#weaponmod:knife",
+    "#weaponmod:spear",
+    "#weaponmod:warhammer",
+    "#weaponmod:musketbayonet",
+    "weaponmod:blowgun",
+    "#weaponmod:boomerang",
+    "weaponmod:blunderbuss",
+    "weaponmod:javelin",
+    "weaponmod:firerod",
+    "weaponmod:crossbow",
+    "weaponmod:cannon",
+    "weaponmod:mortar",
+    "weaponmod:flintlock"
+  ]
+}

--- a/common/src/main/resources/data/minecraft/tags/item/enchantable/durability.json
+++ b/common/src/main/resources/data/minecraft/tags/item/enchantable/durability.json
@@ -1,0 +1,20 @@
+{
+  "values": [
+    "#weaponmod:battleaxe",
+    "#weaponmod:flail",
+    "#weaponmod:halberd",
+    "#weaponmod:katana",
+    "#weaponmod:knife",
+    "#weaponmod:spear",
+    "#weaponmod:warhammer",
+    "#weaponmod:musketbayonet",
+    "weaponmod:blowgun",
+    "#weaponmod:boomerang",
+    "weaponmod:blunderbuss",
+    "weaponmod:javelin",
+    "weaponmod:firerod",
+    "weaponmod:crossbow",
+    "weaponmod:mortar",
+    "weaponmod:flintlock"
+  ]
+}

--- a/common/src/main/resources/data/minecraft/tags/item/enchantable/fire_aspect.json
+++ b/common/src/main/resources/data/minecraft/tags/item/enchantable/fire_aspect.json
@@ -1,0 +1,13 @@
+{
+  "values": [
+    "#weaponmod:battleaxe",
+    "#weaponmod:flail",
+    "#weaponmod:halberd",
+    "#weaponmod:katana",
+    "#weaponmod:knife",
+    "#weaponmod:spear",
+    "#weaponmod:warhammer",
+    "#weaponmod:musketbayonet",
+    "#weaponmod:boomerang" 
+  ]
+}

--- a/common/src/main/resources/data/minecraft/tags/item/enchantable/sharp_weapon.json
+++ b/common/src/main/resources/data/minecraft/tags/item/enchantable/sharp_weapon.json
@@ -1,0 +1,14 @@
+{
+  "values": [
+    "#weaponmod:battleaxe",
+    "#weaponmod:flail",
+    "#weaponmod:halberd",
+    "#weaponmod:katana",
+    "#weaponmod:knife",
+    "#weaponmod:spear",
+    "#weaponmod:warhammer",
+    "#weaponmod:musketbayonet",
+    "weaponmod:firerod",
+    "weaponmod:javelin"
+  ]
+}

--- a/common/src/main/resources/data/minecraft/tags/item/enchantable/sword.json
+++ b/common/src/main/resources/data/minecraft/tags/item/enchantable/sword.json
@@ -1,0 +1,13 @@
+{
+  "values": [
+    "#weaponmod:battleaxe",
+    "#weaponmod:flail",
+    "#weaponmod:halberd",
+    "#weaponmod:katana",
+    "#weaponmod:knife",
+    "#weaponmod:spear",
+    "#weaponmod:warhammer",
+    "#weaponmod:musketbayonet",
+    "weaponmod:javelin"
+  ]
+}

--- a/common/src/main/resources/data/minecraft/tags/item/enchantable/trident.json
+++ b/common/src/main/resources/data/minecraft/tags/item/enchantable/trident.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "weaponmod:javelin"
+  ]
+}

--- a/common/src/main/resources/data/minecraft/tags/item/enchantable/weapon.json
+++ b/common/src/main/resources/data/minecraft/tags/item/enchantable/weapon.json
@@ -1,0 +1,13 @@
+{
+  "values": [
+    "#weaponmod:battleaxe",
+    "#weaponmod:flail",
+    "#weaponmod:halberd",
+    "#weaponmod:katana",
+    "#weaponmod:knife",
+    "#weaponmod:spear",
+    "#weaponmod:warhammer",
+    "#weaponmod:musketbayonet",
+    "weaponmod:javelin"
+  ]
+}

--- a/common/src/main/resources/data/weaponmod/tags/item/battleaxe.json
+++ b/common/src/main/resources/data/weaponmod/tags/item/battleaxe.json
@@ -1,0 +1,11 @@
+{
+  "replace": false,
+  "values": [
+    "weaponmod:battleaxe.netherite",
+    "weaponmod:battleaxe.diamond",
+    "weaponmod:battleaxe.iron",
+    "weaponmod:battleaxe.gold",
+    "weaponmod:battleaxe.stone",
+    "weaponmod:battleaxe.wood"
+  ]
+}

--- a/common/src/main/resources/data/weaponmod/tags/item/boomerang.json
+++ b/common/src/main/resources/data/weaponmod/tags/item/boomerang.json
@@ -1,0 +1,11 @@
+{
+  "replace": false,
+  "values": [
+    "weaponmod:boomerang.netherite",
+    "weaponmod:boomerang.diamond",
+    "weaponmod:boomerang.iron",
+    "weaponmod:boomerang.gold",
+    "weaponmod:boomerang.stone",
+    "weaponmod:boomerang.wood"
+  ]
+}

--- a/common/src/main/resources/data/weaponmod/tags/item/flail.json
+++ b/common/src/main/resources/data/weaponmod/tags/item/flail.json
@@ -1,0 +1,11 @@
+{
+  "replace": false,
+  "values": [
+    "weaponmod:flail.netherite",
+    "weaponmod:flail.diamond",
+    "weaponmod:flail.iron",
+    "weaponmod:flail.gold",
+    "weaponmod:flail.stone",
+    "weaponmod:flail.wood"
+  ]
+}

--- a/common/src/main/resources/data/weaponmod/tags/item/halberd.json
+++ b/common/src/main/resources/data/weaponmod/tags/item/halberd.json
@@ -1,0 +1,11 @@
+{
+  "replace": false,
+  "values": [
+    "weaponmod:halberd.netherite",
+    "weaponmod:halberd.diamond",
+    "weaponmod:halberd.iron",
+    "weaponmod:halberd.gold",
+    "weaponmod:halberd.stone",
+    "weaponmod:halberd.wood"
+  ]
+}

--- a/common/src/main/resources/data/weaponmod/tags/item/katana.json
+++ b/common/src/main/resources/data/weaponmod/tags/item/katana.json
@@ -1,0 +1,11 @@
+{
+  "replace": false,
+  "values": [
+    "weaponmod:katana.netherite",
+    "weaponmod:katana.diamond",
+    "weaponmod:katana.iron",
+    "weaponmod:katana.gold",
+    "weaponmod:katana.stone",
+    "weaponmod:katana.wood"
+  ]
+}

--- a/common/src/main/resources/data/weaponmod/tags/item/knife.json
+++ b/common/src/main/resources/data/weaponmod/tags/item/knife.json
@@ -1,0 +1,11 @@
+{
+  "replace": false,
+  "values": [
+    "weaponmod:knife.netherite",
+    "weaponmod:knife.diamond",
+    "weaponmod:knife.iron",
+    "weaponmod:knife.gold",
+    "weaponmod:knife.stone",
+    "weaponmod:knife.wood"
+  ]
+}

--- a/common/src/main/resources/data/weaponmod/tags/item/musketbayonet.json
+++ b/common/src/main/resources/data/weaponmod/tags/item/musketbayonet.json
@@ -1,0 +1,11 @@
+{
+  "replace": false,
+  "values": [
+    "weaponmod:musketbayonet.netherite",
+    "weaponmod:musketbayonet.diamond",
+    "weaponmod:musketbayonet.iron",
+    "weaponmod:musketbayonet.gold",
+    "weaponmod:musketbayonet.stone",
+    "weaponmod:musketbayonet.wood"
+  ]
+}

--- a/common/src/main/resources/data/weaponmod/tags/item/spear.json
+++ b/common/src/main/resources/data/weaponmod/tags/item/spear.json
@@ -1,0 +1,11 @@
+{
+  "replace": false,
+  "values": [
+    "weaponmod:spear.netherite",
+    "weaponmod:spear.diamond",
+    "weaponmod:spear.iron",
+    "weaponmod:spear.gold",
+    "weaponmod:spear.stone",
+    "weaponmod:spear.wood"
+  ]
+}

--- a/common/src/main/resources/data/weaponmod/tags/item/warhammer.json
+++ b/common/src/main/resources/data/weaponmod/tags/item/warhammer.json
@@ -1,0 +1,11 @@
+{
+  "replace": false,
+  "values": [
+    "weaponmod:warhammer.netherite",
+    "weaponmod:warhammer.diamond",
+    "weaponmod:warhammer.iron",
+    "weaponmod:warhammer.gold",
+    "weaponmod:warhammer.stone",
+    "weaponmod:warhammer.wood"
+  ]
+}


### PR DESCRIPTION
I added item tags and enchantment tags to enable compatibility with some vanilla Minecraft enchantments.
I’m aware this isn’t the most ideal or "official" way to handle enchantments, but I just can't wait anymore.
Item | Supported Enchantments
-- | --
Battleaxe | Sharpness, Smite, Bane of Arthropods, Sweeping Edge, Fire Aspect, Knockback, Looting, Unbreaking, Mending, Curse of Vanishing
Blowgun | Unbreaking, Mending, Curse of Vanishing
Blunderbuss | Unbreaking, Mending, Curse of Vanishing
Boomerang | Fire Aspect, Unbreaking, Mending, Curse of Vanishing
Crossbow | Unbreaking, Mending, Curse of Vanishing
Firerod | Sharpness, Smite, Bane of Arthropods, Unbreaking, Mending, Curse of Vanishing
Flail | Sharpness, Smite, Bane of Arthropods, Sweeping Edge, Fire Aspect, Knockback, Looting, Unbreaking, Mending, Curse of Vanishing
Flintlock | Unbreaking, Mending, Curse of Vanishing
Halberd | Sharpness, Smite, Bane of Arthropods, Sweeping Edge, Fire Aspect, Knockback, Looting, Unbreaking, Mending, Curse of Vanishing
Hand Mortar | Unbreaking, Mending, Curse of Vanishing
Javelin | –
Katana | Sharpness, Smite, Bane of Arthropods, Sweeping Edge, Fire Aspect, Knockback, Looting, Unbreaking, Mending, Curse of Vanishing
Knife | Sharpness, Smite, Bane of Arthropods, Sweeping Edge, Fire Aspect, Knockback, Looting, Unbreaking, Mending, Curse of Vanishing
Musket | Unbreaking, Mending, Curse of Vanishing
Musket (Bayonet) | Sharpness, Smite, Bane of Arthropods, Sweeping Edge, Fire Aspect, Knockback, Looting, Unbreaking, Mending, Curse of Vanishing
Spear | Sharpness, Smite, Bane of Arthropods, Sweeping Edge, Fire Aspect, Knockback, Looting, Unbreaking, Mending, Curse of Vanishing
Warhammer | Sharpness, Smite, Bane of Arthropods, Sweeping Edge, Fire Aspect, Knockback, Looting, Unbreaking, Mending, Curse of Vanishing